### PR TITLE
Expose binding functionality to scripts

### DIFF
--- a/Mond.BindingEx/Library/InteropLibrary.cs
+++ b/Mond.BindingEx/Library/InteropLibrary.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mond.Libraries;
+
+namespace Mond.BindingEx.Library
+{
+    public class InteropLibraries : IMondLibraryCollection
+    {
+        public IEnumerable<IMondLibrary> Create( MondState state )
+        {
+            yield return new InteropLibrary();
+        }
+    }
+
+    public class InteropLibrary : IMondLibrary
+    {
+        public IEnumerable<KeyValuePair<string, MondValue>> GetDefinitions()
+        {
+            var importNamespace = new MondValue( (state, instance, args) => new NamespaceReference( args[0] ).ToMond( state ) );
+            yield return new KeyValuePair<string, MondValue>( "importNamespace", importNamespace );
+        }
+
+        internal static Type LookupType( string typeName )
+        {
+            var type = Type.GetType( typeName );
+            if( type != null )
+                return type;
+
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            return assemblies.Select( a => a.GetType( typeName ) ).FirstOrDefault( t => t != null );
+        }
+
+        internal static Type[] GetTypeArray( MondValue[] values )
+        {
+            var types = new Type[values.Length];
+
+            for( var i = 0; i < values.Length; ++i )
+            {
+                var value = values[i];
+                
+                if( value.Type != MondValueType.Object || !(value.UserData is TypeReference) )
+                    throw new ArgumentException( "Argument #{0} is not a CLR type".With( i - 1 ), "values" );
+
+                types[i] = ((TypeReference)value.UserData).Type;
+            }
+
+            return types;
+        }
+    }
+}

--- a/Mond.BindingEx/Library/NamespaceReference.cs
+++ b/Mond.BindingEx/Library/NamespaceReference.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Mond.Binding;
+
+namespace Mond.BindingEx.Library
+{
+    [MondClass]
+    internal class NamespaceReference
+    {
+        private readonly string _path;
+
+        public NamespaceReference( string path )
+        {
+            if( string.IsNullOrWhiteSpace(path) )
+                throw new ArgumentNullException( "path" );
+
+            _path = path;
+        }
+
+        /// <summary>
+        /// Navigate namespaces or get a top-level type.
+        /// </summary>
+        [MondFunction( "__get" )]
+        public MondValue Get( MondState state, MondValue instance, string name )
+        {
+            var newPath = _path + "." + name;
+
+            var type = InteropLibrary.LookupType( newPath );   
+            if( type != null )
+                return MondObjectBinder.Bind( type, state, MondBindingOptions.AutoLock );
+
+            return new NamespaceReference( newPath ).ToMond( state );
+        }
+
+        /// <summary>
+        /// Binds type arguments to a generic type. Only used when the type does not have
+        /// an overload with no type arguments.
+        /// </summary>
+        [MondFunction( "__call" )]
+        public MondValue Call( MondState state, MondValue instance, params MondValue[] args )
+        {
+            var types = InteropLibrary.GetTypeArray( args );
+
+            var typeName = _path + "`" + types.Length;
+            var type = InteropLibrary.LookupType( typeName );
+            if( type == null )
+                throw new Exception( "Could not find type: " + typeName );
+
+            var boundType = type.MakeGenericType( types );
+            return MondObjectBinder.Bind( boundType, state, MondBindingOptions.AutoLock );
+        }
+
+        [MondFunction( "__string" )]
+        public string String( MondValue instance )
+        {
+            return _path;
+        }
+
+        public MondValue ToMond( MondState state )
+        {
+            MondValue prototype;
+            MondClassBinder.Bind<NamespaceReference>( out prototype, state );
+
+            var obj = new MondValue( state );
+            obj.UserData = this;
+            obj.Prototype = prototype;
+            obj.Lock();
+
+            return obj;
+        }
+    }
+}

--- a/Mond.BindingEx/Library/TypeReference.cs
+++ b/Mond.BindingEx/Library/TypeReference.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Mond.Binding;
+
+namespace Mond.BindingEx.Library
+{
+    [MondClass]
+    internal class TypeReference
+    {
+        public Type Type { get; private set; }
+
+        public TypeReference( Type type )
+        {
+            if( type == null )
+                throw new ArgumentNullException("type");
+
+            Type = type;
+        }
+
+        /// <summary>
+        /// Get a nested type.
+        /// </summary>
+        [MondFunction( "__get" )]
+        public MondValue Get( MondState state, MondValue instance, string name )
+        {
+            var typeName = Type.FullName + "+" + name;
+
+            var type = InteropLibrary.LookupType( typeName );
+            if( type == null )
+                throw new Exception( "Could not find type: " + typeName );
+
+            return MondObjectBinder.Bind( type, state, MondBindingOptions.AutoLock );
+        }
+        
+        /// <summary>
+        /// Bind type arguments to a generic type. Only used when the type has an overload
+        /// with no type arguments.
+        /// </summary>
+        [MondFunction( "__call" )]
+        public MondValue Call( MondState state, MondValue instance, params MondValue[] args )
+        {
+            if( Type.IsGenericType && !Type.ContainsGenericParameters )
+                throw new Exception( "Generic type is already bound: " + Type.FullName );
+
+            var types = InteropLibrary.GetTypeArray( args );
+
+            var typeName = Type.FullName + "`" + types.Length;
+            var type = InteropLibrary.LookupType( typeName );
+            if( type == null )
+                throw new Exception( "Could not find type: " + typeName );
+
+            var boundType = type.MakeGenericType( types );
+            return MondObjectBinder.Bind( boundType, state, MondBindingOptions.AutoLock );
+        }
+
+        [MondFunction( "__string" )]
+        public string String( MondValue instance )
+        {
+            return Type.FullName;
+        }
+    }
+}

--- a/Mond.BindingEx/Mond.BindingEx.csproj
+++ b/Mond.BindingEx/Mond.BindingEx.csproj
@@ -43,6 +43,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Library\InteropLibrary.cs" />
+    <Compile Include="Library\NamespaceReference.cs" />
+    <Compile Include="Library\TypeReference.cs" />
     <Compile Include="Utils\Extensions\MemberInfoExtensions.cs" />
     <Compile Include="MondAliasAttribute.cs" />
     <Compile Include="BindingException.cs" />


### PR DESCRIPTION
This should be all we need for #4. It allows scripts to access types like this:

```
var System = importNamespace("System");
var list1 = System.Collections.Generic.List(System.Action).new();
var list2 = System.Collections.Generic.List(System.Action(System.String)).new();
printLn(list1);
printLn(list2);
```
